### PR TITLE
Remove "babel-runtime" dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "plugins": [
-    "transform-flow-strip-types",
-    "transform-runtime",
+    "transform-flow-strip-types"
   ],
   "presets" : [
     "env",


### PR DESCRIPTION
"transform-runtime" plugin replace

```
var _stringify = require('babel-runtime/core-js/json/stringify');
var _stringify2 = _interopRequireDefault(_stringify);
var blob = (0, _stringify2.default)(json, undefined, 2);
```
instead 
```
var blob = JSON.stringify(json, undefined, 2);
```
and this code doesn't work without "babel-runtime"

This pull request remove babel "transform-runtime" plugin
